### PR TITLE
Fix grammar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,7 +78,7 @@
           <i class="ri-github-line px-4 text-3xl text-gray-400"></i>
           <div class="flex flex-col">
             <span class="font-bold">See source</span>
-            <span class="text-sm">Visit our GitHub</span>
+            <span class="text-sm">Visit our GitHub repo</span>
           </div>
         </a>
       </nav>


### PR DESCRIPTION
"Visit our GitHub" makes no sense (unless if you're running your own instance of GitHub which you're not),. "Visit our Github repo/repository" does. Fix that.