### PR TITLE
link to livebook desktop with notebook url

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -213,6 +213,10 @@ if (document.body.dataset.page === "run") {
   const runNotebookLinkEls = document.querySelectorAll(
     `[data-el="run-notebook-link"]`
   );
+  const runNotebookViaDesktopLinkEls = document.querySelectorAll(
+    `[data-el="run-notebook-via-desktop"]`
+  );
+
   const notebookPreviewEl = document.querySelector(
     `[data-el="notebook-preview"]`
   );
@@ -239,6 +243,10 @@ if (document.body.dataset.page === "run") {
   });
 
   notebookSourceLinkEl.setAttribute("href", notebookUrl);
+
+  for (const runNotebookViaDesktopLinkEl of runNotebookViaDesktopLinkEls) {
+    runNotebookViaDesktopLinkEl.setAttribute("href", `livebook://${notebookUrl}`);
+  }
 
   getNotebookContent(notebookUrl)
     .then((livemd) => {

--- a/src/partials/settings_sections.html
+++ b/src/partials/settings_sections.html
@@ -30,6 +30,13 @@
           spellcheck="false"
           autocomplete="off"
         />
+        <a
+          data-el="run-notebook-via-desktop"
+          class="mt-8 self-center button button-blue"
+          href="#"
+        >
+          I'm using Livebook Desktop 
+        </a>
         <div data-el="livebook-status" class="mt-1">
           <span
             data-show-on-status="up"


### PR DESCRIPTION
Adds the ability to run with Livebook Desktop livebook-dev/livebook#912

![screenshot2022-01-22-20 55 47](https://user-images.githubusercontent.com/1639/150661636-5f872296-61bf-4862-8537-deadb1f05579.png)

This currently has a problem picking up a second http scheme prefix on the trip through liveview desktop protocol handler.

![screenshot2022-01-22-21 00 11](https://user-images.githubusercontent.com/1639/150661664-0d119bbf-0c8e-4ff2-8d42-b837756925e4.png)

I think this might be coming from within Liveview Desktop as it's passed along.

Lastly, acknowledging we may want to just close this until Liveview Desktop is ready for promotion. As mentioned in #19